### PR TITLE
Resolves #130: Add bulletin board

### DIFF
--- a/components/bulletin-board.module.css
+++ b/components/bulletin-board.module.css
@@ -1,0 +1,8 @@
+.bulletinBoard {
+  position: absolute;
+
+  height: 100px;
+  width: 100px;
+  image-rendering: pixelated;
+  z-index: 3;
+}

--- a/components/bulletin-board.tsx
+++ b/components/bulletin-board.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import styles from "./bulletin-board.module.css";
+
+interface Props {
+  spawn: MapCoordinates;
+}
+
+export default function BulletinBoard(props: Props) {
+  return (
+    <img
+      className={styles.bulletinBoard}
+      src="/static/bulletin-board.svg"
+      alt="bulletin board"
+      style={{
+        left: props.spawn.x * 100,
+        top: props.spawn.y * 100,
+      }}
+    />
+  );
+}

--- a/components/constants.js
+++ b/components/constants.js
@@ -695,3 +695,8 @@ export const ENTRANCES = [
   { spawn: { x: 8, y: 42 }, href: "/cave", label: "Cave", image: "/static/building-cave.svg" },
   { spawn: { x: 6, y: 7 }, href: "/room", label: "House", image: "/static/building-house.svg" },
 ];
+
+export const BULLETIN_BOARDS = [
+  // Village square, just south of the town hall
+  { spawn: { x: 27, y: 22 } },
+];

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,11 +6,12 @@ import Map from "components/map";
 import NPC from "components/npc";
 import Prize from "components/prize";
 import Rock from "components/rock";
+import BulletinBoard from "components/bulletin-board";
 import SpeechBox from "components/speech-box";
 import ClueJournal from "components/clue-journal";
 import GameContext from "components/game-context";
 
-import { NPCS, NPC_DIALOGUE, ROCKS, WATER, ENTRANCES, getNpcReaction } from "components/constants";
+import { NPCS, NPC_DIALOGUE, ROCKS, WATER, ENTRANCES, BULLETIN_BOARDS, getNpcReaction } from "components/constants";
 import useMapScroll from "../hooks/useMapScroll";
 import MapDebug from "../components/map-debug";
 
@@ -161,6 +162,13 @@ export default React.memo(function App() {
           key={`rock_x${spawn.x}_y${spawn.y}`}
           spawn={spawn}
           variant={variant}
+        />
+      ))}
+
+      {BULLETIN_BOARDS.map(({ spawn }) => (
+        <BulletinBoard
+          key={`bulletin_board_x${spawn.x}_y${spawn.y}`}
+          spawn={spawn}
         />
       ))}
 

--- a/public/static/bulletin-board.svg
+++ b/public/static/bulletin-board.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" shape-rendering="crispEdges">
+  <!-- Roof -->
+  <rect x="1" y="2" width="18" height="1" fill="#5C3A1E"/>
+  <rect x="2" y="3" width="16" height="1" fill="#7A5230"/>
+  <!-- Frame -->
+  <rect x="2" y="4" width="16" height="10" fill="#8B5A2B"/>
+  <rect x="2" y="4" width="16" height="1" fill="#A0703C"/>
+  <!-- Cork surface -->
+  <rect x="3" y="5" width="14" height="8" fill="#C8A165"/>
+  <rect x="3" y="12" width="14" height="1" fill="#B08B54"/>
+  <!-- Pinned notice, upper left -->
+  <rect x="4" y="6" width="4" height="3" fill="#F5E6C8"/>
+  <rect x="5" y="7" width="2" height="1" fill="#4A4038"/>
+  <rect x="5" y="6" width="1" height="1" fill="#CD5C5C"/>
+  <!-- Pinned notice, upper middle -->
+  <rect x="9" y="6" width="3" height="4" fill="#FFFDF0"/>
+  <rect x="9" y="8" width="2" height="1" fill="#4A4038"/>
+  <rect x="10" y="6" width="1" height="1" fill="#5B8C5A"/>
+  <!-- Pinned notice, upper right -->
+  <rect x="13" y="6" width="3" height="3" fill="#EDD9B5"/>
+  <rect x="14" y="6" width="1" height="1" fill="#4A7BA7"/>
+  <!-- Pinned notice, lower left -->
+  <rect x="4" y="10" width="6" height="2" fill="#F5E6C8"/>
+  <rect x="5" y="11" width="4" height="1" fill="#4A4038"/>
+  <!-- Pinned notice, lower right -->
+  <rect x="13" y="10" width="3" height="2" fill="#FFFDF0"/>
+  <!-- Posts -->
+  <rect x="4" y="14" width="2" height="5" fill="#6B4A2F"/>
+  <rect x="4" y="14" width="1" height="5" fill="#7F5936"/>
+  <rect x="14" y="14" width="2" height="5" fill="#6B4A2F"/>
+  <rect x="14" y="14" width="1" height="5" fill="#7F5936"/>
+  <!-- Trodden dirt -->
+  <rect x="3" y="19" width="4" height="1" fill="#7A6A4F"/>
+  <rect x="13" y="19" width="4" height="1" fill="#7A6A4F"/>
+</svg>


### PR DESCRIPTION
Resolves #130.

Adds a bulletin board sprite to the overworld map:
- `public/static/bulletin-board.svg` — pixel-art sprite matching existing style (wood frame, cork surface, pushpins)
- `components/bulletin-board.tsx` + CSS module — positioned via tile coordinates like other map objects
- `components/constants.js` — new `BULLETIN_BOARDS` array for easy placement of more later
- Placed at tile (27, 22) in the village square, south of the town hall

Purely decorative for now (no interaction, no movement blocking), per 'just the sprite for now.'