### PR TITLE
Resolves #30: Add tree

### DIFF
--- a/components/constants.js
+++ b/components/constants.js
@@ -588,6 +588,12 @@ export const ROCKS = [
   { spawn: { y: 30, x: 33 }, variant: 1 },
 ];
 
+// Spawn is the stump's tile, which is blocked. The canopy hangs over the tile
+// above it, which stays walkable so characters can pass behind the leaves.
+export const TREES = [
+  { spawn: { y: 22, x: 24 } },
+];
+
 export const WATER = [
   // Waterfall stream near cave (cave entrance at x:8, y:42)
   { spawn: { x: 8, y: 40 } },

--- a/components/map.js
+++ b/components/map.js
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 
 import GameContext from "./game-context";
 import { coordsToIndex, indexToCoords } from "./utils";
-import { ROCKS, WATER, ENTRANCES } from "./constants";
+import { ROCKS, TREES, WATER, ENTRANCES } from "./constants";
 
 import styles from "./map.module.css";
 
@@ -43,9 +43,9 @@ export default function Map(props) {
     }
     setBackgroundIds(backgroundIds);
 
-    // block rocks, water, entrances on the main overworld map only
+    // block rocks, tree stumps, water, entrances on the main overworld map only
     if (router.pathname === "/") {
-      const blockedItems = [...ROCKS, ...WATER];
+      const blockedItems = [...ROCKS, ...TREES, ...WATER];
       ENTRANCES.forEach(({ spawn }) => {
         blockedItems.push({ spawn });
       });

--- a/components/tree.module.css
+++ b/components/tree.module.css
@@ -1,0 +1,19 @@
+.canopy,
+.stump {
+  position: absolute;
+
+  height: 100px;
+  width: 100px;
+  image-rendering: pixelated;
+}
+
+/* Above characters (z-index 5), so they pass behind the leaves. */
+.canopy {
+  z-index: 6;
+  pointer-events: none;
+}
+
+/* Below characters, alongside the rocks. */
+.stump {
+  z-index: 3;
+}

--- a/components/tree.tsx
+++ b/components/tree.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import styles from "./tree.module.css";
+
+interface Props {
+  spawn: MapCoordinates;
+}
+
+// The spawn coordinates are the tree's stump, which blocks its tile. The canopy
+// sits on the tile above and renders over characters so they can walk behind it.
+export default function Tree(props: Props) {
+  return (
+    <>
+      <img
+        className={styles.canopy}
+        src="/static/tree-canopy.svg"
+        style={{
+          left: props.spawn.x * 100,
+          top: (props.spawn.y - 1) * 100,
+        }}
+      />
+      <img
+        className={styles.stump}
+        src="/static/tree-stump.svg"
+        style={{
+          left: props.spawn.x * 100,
+          top: props.spawn.y * 100,
+        }}
+      />
+    </>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,10 +7,11 @@ import NPC from "components/npc";
 import Prize from "components/prize";
 import Rock from "components/rock";
 import SpeechBox from "components/speech-box";
+import Tree from "components/tree";
 import ClueJournal from "components/clue-journal";
 import GameContext from "components/game-context";
 
-import { NPCS, NPC_DIALOGUE, ROCKS, WATER, ENTRANCES, getNpcReaction } from "components/constants";
+import { NPCS, NPC_DIALOGUE, ROCKS, TREES, WATER, ENTRANCES, getNpcReaction } from "components/constants";
 import useMapScroll from "../hooks/useMapScroll";
 import MapDebug from "../components/map-debug";
 
@@ -162,6 +163,10 @@ export default React.memo(function App() {
           spawn={spawn}
           variant={variant}
         />
+      ))}
+
+      {TREES.map(({ spawn }) => (
+        <Tree key={`tree_x${spawn.x}_y${spawn.y}`} spawn={spawn} />
       ))}
 
       {ENTRANCES.map(({ spawn, href, label, image }) => (

--- a/public/static/tree-canopy.svg
+++ b/public/static/tree-canopy.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" shape-rendering="crispEdges">
+  <!-- Trunk continuing up under the leaves -->
+  <rect x="8" y="12" width="4" height="8" fill="#7A5230"/>
+  <rect x="8" y="12" width="1" height="8" fill="#8B6039"/>
+  <rect x="11" y="12" width="1" height="8" fill="#5E3D22"/>
+  <!-- Foliage body -->
+  <rect x="4" y="3" width="12" height="10" fill="#3E7C42"/>
+  <rect x="2" y="6" width="16" height="5" fill="#3E7C42"/>
+  <rect x="6" y="1" width="8" height="2" fill="#3E7C42"/>
+  <!-- Shadowed side -->
+  <rect x="6" y="11" width="7" height="2" fill="#357038"/>
+  <rect x="16" y="6" width="2" height="2" fill="#357038"/>
+  <rect x="14" y="8" width="4" height="3" fill="#2C5E31"/>
+  <rect x="13" y="11" width="4" height="2" fill="#2C5E31"/>
+  <!-- Lower leaf clumps -->
+  <rect x="5" y="13" width="4" height="1" fill="#357038"/>
+  <rect x="12" y="13" width="4" height="1" fill="#2C5E31"/>
+  <rect x="7" y="14" width="2" height="1" fill="#2C5E31"/>
+  <rect x="12" y="14" width="2" height="1" fill="#2C5E31"/>
+  <!-- Highlights -->
+  <rect x="5" y="4" width="6" height="2" fill="#55A65A"/>
+  <rect x="3" y="7" width="3" height="2" fill="#55A65A"/>
+  <rect x="7" y="2" width="4" height="1" fill="#55A65A"/>
+  <rect x="6" y="6" width="2" height="1" fill="#6DBF71"/>
+  <rect x="4" y="9" width="1" height="1" fill="#6DBF71"/>
+  <rect x="9" y="3" width="1" height="1" fill="#6DBF71"/>
+</svg>

--- a/public/static/tree-stump.svg
+++ b/public/static/tree-stump.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" shape-rendering="crispEdges">
+  <!-- Trunk -->
+  <rect x="8" y="0" width="4" height="15" fill="#7A5230"/>
+  <rect x="8" y="0" width="1" height="15" fill="#8B6039"/>
+  <rect x="11" y="0" width="1" height="15" fill="#5E3D22"/>
+  <!-- Bark texture -->
+  <rect x="10" y="3" width="1" height="2" fill="#5E3D22"/>
+  <rect x="9" y="8" width="1" height="2" fill="#5E3D22"/>
+  <rect x="10" y="11" width="1" height="1" fill="#8B6039"/>
+  <!-- Roots -->
+  <rect x="6" y="13" width="2" height="2" fill="#7A5230"/>
+  <rect x="12" y="13" width="2" height="2" fill="#5E3D22"/>
+  <rect x="5" y="15" width="10" height="1" fill="#6B4A2F"/>
+  <!-- Base shadow -->
+  <rect x="5" y="16" width="10" height="1" fill="#2C5E31" opacity="0.5"/>
+  <!-- Grass tufts around the stump -->
+  <rect x="4" y="15" width="2" height="1" fill="#3E7C42"/>
+  <rect x="14" y="15" width="2" height="1" fill="#3E7C42"/>
+  <rect x="5" y="14" width="1" height="1" fill="#55A65A"/>
+  <rect x="15" y="14" width="1" height="1" fill="#55A65A"/>
+</svg>


### PR DESCRIPTION
Resolves #30.

Adds a tree sprite with proper walk-behind layering:
- `public/static/tree-canopy.svg` + `tree-stump.svg` — two-tile pixel art tree
- `components/tree.tsx` — renders canopy at z-index 6 (above characters), stump at z-index 3
- Stump tile added to `blockedItems` in `map.js` so player can't walk through trunk
- Canopy tile is walkable — player walks 'behind' the tree visually
- `TREES` array in constants; one tree placed at tile (24, 22) near the village square