### PR TITLE
Resolves #17: Dark mode ghost

### DIFF
--- a/components/ghost.module.css
+++ b/components/ghost.module.css
@@ -1,0 +1,31 @@
+.ghost {
+  position: absolute;
+
+  height: 100px;
+  width: 100px;
+  z-index: 4;
+
+  display: none;
+  pointer-events: none;
+  image-rendering: pixelated;
+}
+
+/* The ghost only haunts the overworld when the device is in dark mode. */
+@media (prefers-color-scheme: dark) {
+  .ghost {
+    display: block;
+    animation: haunt 4s ease-in-out infinite;
+  }
+}
+
+@keyframes haunt {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 0.9;
+    transform: translateY(-10px);
+  }
+}

--- a/components/ghost.tsx
+++ b/components/ghost.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import styles from "./ghost.module.css";
+
+interface Props {
+  spawn: MapCoordinates;
+}
+
+export default function Ghost(props: Props) {
+  return (
+    <img
+      className={styles.ghost}
+      data-cy="ghost"
+      src="/static/ghost.svg"
+      alt="a ghost"
+      style={{
+        left: props.spawn.x * 100,
+        top: props.spawn.y * 100,
+      }}
+    />
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import Head from "next/head";
 import Link from "next/link";
 
+import Ghost from "components/ghost";
 import Map from "components/map";
 import NPC from "components/npc";
 import Prize from "components/prize";
@@ -163,6 +164,9 @@ export default React.memo(function App() {
           variant={variant}
         />
       ))}
+
+      {/* Haunts the rocks by the cave stream, but only in dark mode */}
+      <Ghost spawn={{ x: 6, y: 42 }} />
 
       {ENTRANCES.map(({ spawn, href, label, image }) => (
         <Link key={`entrance_${href}`} href={href} data-cy={`${href.replace("/", "")}-link`}>

--- a/public/static/ghost.svg
+++ b/public/static/ghost.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" shape-rendering="crispEdges">
+  <!-- Faint glow around the ghost -->
+  <rect x="9" y="0" width="2" height="1" fill="#BFE9F5" opacity="0.35"/>
+  <rect x="3" y="6" width="1" height="1" fill="#BFE9F5" opacity="0.35"/>
+  <rect x="16" y="9" width="1" height="1" fill="#BFE9F5" opacity="0.35"/>
+  <rect x="4" y="12" width="1" height="1" fill="#BFE9F5" opacity="0.35"/>
+  <rect x="15" y="4" width="1" height="1" fill="#BFE9F5" opacity="0.35"/>
+
+  <g opacity="0.82">
+    <!-- Body silhouette, top to bottom -->
+    <rect x="8" y="2" width="4" height="1" fill="#F0F6FF"/>
+    <rect x="7" y="3" width="6" height="1" fill="#F0F6FF"/>
+    <rect x="6" y="4" width="8" height="1" fill="#F0F6FF"/>
+    <rect x="5" y="5" width="10" height="9" fill="#F0F6FF"/>
+
+    <!-- Wavy sheet hem -->
+    <rect x="5" y="14" width="2" height="1" fill="#F0F6FF"/>
+    <rect x="8" y="14" width="4" height="1" fill="#F0F6FF"/>
+    <rect x="13" y="14" width="2" height="1" fill="#F0F6FF"/>
+    <rect x="5" y="15" width="1" height="1" fill="#F0F6FF"/>
+    <rect x="9" y="15" width="2" height="1" fill="#F0F6FF"/>
+    <rect x="14" y="15" width="1" height="1" fill="#F0F6FF"/>
+
+    <!-- Cool shading down the right side -->
+    <rect x="13" y="5" width="2" height="9" fill="#C9D9EC"/>
+    <rect x="12" y="4" width="2" height="1" fill="#C9D9EC"/>
+    <rect x="13" y="14" width="2" height="1" fill="#C9D9EC"/>
+    <rect x="14" y="15" width="1" height="1" fill="#C9D9EC"/>
+
+    <!-- Highlight down the left side -->
+    <rect x="6" y="5" width="1" height="8" fill="#FFFFFF"/>
+    <rect x="7" y="3" width="1" height="1" fill="#FFFFFF"/>
+
+    <!-- Hollow eyes -->
+    <rect x="7" y="7" width="2" height="3" fill="#2E2C31"/>
+    <rect x="11" y="7" width="2" height="3" fill="#2E2C31"/>
+
+    <!-- Wailing mouth -->
+    <rect x="9" y="11" width="2" height="2" fill="#2E2C31"/>
+    <rect x="9" y="10" width="2" height="1" fill="#2E2C31" opacity="0.5"/>
+  </g>
+</svg>


### PR DESCRIPTION
Resolves #17.

Adds a ghost sprite that only appears in dark mode:
- `public/static/ghost.svg` — pixel-art ghost (20×20, translucent sheet, hollow eyes, wavy hem)
- `components/ghost.tsx` — renders at tile coordinates like other scenery components
- `components/ghost.module.css` — `display: none` by default; `@media (prefers-color-scheme: dark)` reveals it with a floating haunt animation
- Placed at tile (6, 42) near the cave entrance / waterfall, non-blocking (`pointer-events: none`)